### PR TITLE
Expose pressable context

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@legendapp/motion",
-    "version": "2.3.0",
+    "version": "2.3.1",
     "description": "legend-motion",
     "sideEffects": false,
     "main": "lib/commonjs/",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,5 @@ export * from './AnimatedComponents';
 export * from './createMotionComponent';
 export * from './Interfaces';
 export * from './AnimatePresence';
+export { ContextPressable } from './MotionPressable';
 export { configureMotion } from './configureMotion';


### PR DESCRIPTION
We should expose `PressableContext` so that more complex behavior is possible particularly for child components. This is important because currently the library does not support functions for `animate`, `whileHover`, etc. and removes important event handlers from `Pressable` making it basically impossible for developers to handle state