### PR TITLE
Added require, import and types to exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
     "react-native": "src/",
     "source": "src/",
     "exports": {
+        "require": "lib/commonjs/",
+        "import": "lib/module/",
+        "types": "index.d.ts",
         ".": "./index.js",
         "./svg": "./svg.js",
         "./linear-gradient": "./linear-gradient.js",


### PR DESCRIPTION
As described in issue #19 we notices this change in the nodejs documetation that says, that it will ignore main, module and types when you have an exports inside your package.json.